### PR TITLE
AndroidAnnotations 4.4.0, annotationProcessor & jcodemodel 3.0.2 tran…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,21 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
+
+ext {
+    COMPILE_SDK_VERSION = 27
+    BUILD_TOOLS_VERSION = "27.0.3"
+    MIN_SDK_VERSION = 15
+    TARGET_SDK_VERSION = 26
+    SUPPORT_VERSION = "27.0.2"
+
+    ANDROID_ANNOTATIONS_VERSION = "4.4.0"
+}
+
 
 allprojects {
     repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 24 12:12:28 KST 2016
+#Thu Nov 23 16:50:24 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/intervalclick-api/build.gradle
+++ b/intervalclick-api/build.gradle
@@ -7,5 +7,5 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-    compile 'org.androidannotations:androidannotations-api:4.1.0'
+    compile "org.androidannotations:androidannotations-api:$ANDROID_ANNOTATIONS_VERSION"
 }

--- a/intervalclick/build.gradle
+++ b/intervalclick/build.gradle
@@ -19,8 +19,7 @@ sourceSets {
 sourceSets.main.compileClasspath += configurations.provided
 
 dependencies {
-    compile "org.androidannotations:androidannotations:4.1.0"
+    compile "org.androidannotations:androidannotations:$ANDROID_ANNOTATIONS_VERSION"
     compile project(':intervalclick-api')
-    compile 'com.helger:jcodemodel:2.8.4'
     provided 'com.google.android:android:4.0.1.2'
 }

--- a/intervalclick/src/main/java/moer/intervalclick/processor/handler/IntervalClickHandler.java
+++ b/intervalclick/src/main/java/moer/intervalclick/processor/handler/IntervalClickHandler.java
@@ -2,6 +2,7 @@ package moer.intervalclick.processor.handler;
 
 import com.helger.jcodemodel.AbstractJClass;
 import com.helger.jcodemodel.JBlock;
+import com.helger.jcodemodel.JCodeModel;
 import com.helger.jcodemodel.JDefinedClass;
 import com.helger.jcodemodel.JExpr;
 import com.helger.jcodemodel.JFieldVar;
@@ -59,8 +60,9 @@ public class IntervalClickHandler extends AbstractViewListenerHandler {
 
     @Override
     protected void makeCall(JBlock listenerMethodBody, JInvocation call, TypeMirror returnType) {
-        JVar currentClickTime = listenerMethodBody.decl(JMod.NONE, JPrimitiveType.LONG, "currentClickMilliseconds", getCodeModel().directClass("android.os.SystemClock").staticInvoke("uptimeMillis"));
-        JVar elapsedTime = listenerMethodBody.decl(JMod.NONE, JPrimitiveType.LONG, "elapsedMilliseconds", JOp.minus(currentClickTime, lastClickMilliseconds));
+
+        JVar currentClickTime = listenerMethodBody.decl(JMod.NONE, getCodeModel().LONG, "currentClickMilliseconds", getCodeModel().directClass("android.os.SystemClock").staticInvoke("uptimeMillis"));
+        JVar elapsedTime = listenerMethodBody.decl(JMod.NONE, getCodeModel().LONG, "elapsedMilliseconds", JOp.minus(currentClickTime, lastClickMilliseconds));
         listenerMethodBody._if(JOp.lte(elapsedTime, intervalTime))._then()._return();
         listenerMethodBody.assign(lastClickMilliseconds, currentClickTime);
         listenerMethodBody.add(call);
@@ -79,8 +81,8 @@ public class IntervalClickHandler extends AbstractViewListenerHandler {
 
     @Override
     protected JMethod createListenerMethod(JDefinedClass listenerAnonymousClass) {
-        intervalTime = listenerAnonymousClass.field(JMod.PRIVATE | JMod.FINAL | JMod.FINAL, Long.class, "MIN_CLICK_INTERVAL_MILLISECONDS", JExpr.lit(intervalMilliseconds));
-        lastClickMilliseconds = listenerAnonymousClass.field(JMod.PRIVATE, JPrimitiveType.LONG, "lastClickMilliseconds", JExpr.lit(0L));
+        intervalTime = listenerAnonymousClass.field(JMod.PRIVATE | JMod.FINAL, Long.class, "MIN_CLICK_INTERVAL_MILLISECONDS", JExpr.lit(intervalMilliseconds));
+        lastClickMilliseconds = listenerAnonymousClass.field(JMod.PRIVATE, getCodeModel().LONG, "lastClickMilliseconds", JExpr.lit(0L));
         return listenerAnonymousClass.method(JMod.PUBLIC, getCodeModel().VOID, "onClick");
     }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,17 +1,28 @@
 apply plugin: 'com.android.application'
-apply plugin: 'android-apt'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.3"
+    compileSdkVersion COMPILE_SDK_VERSION
+    buildToolsVersion BUILD_TOOLS_VERSION
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 
     defaultConfig {
         applicationId "moer.intervalclick.sample"
-        minSdkVersion 15
-        targetSdkVersion 24
+        minSdkVersion MIN_SDK_VERSION
+        targetSdkVersion TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0.0"
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = ["resourcePackageName": "moer.intervalclick"]
+            }
+        }
     }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -21,11 +32,14 @@ android {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    apt "org.androidannotations:androidannotations:4.1.0"
-    compile 'org.androidannotations:androidannotations-api:4.1.0'
-    apt project(':intervalclick')
-    compile project(':intervalclick-api')
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.android.support:design:24.2.1'
+    testImplementation 'junit:junit:4.12'
+
+    annotationProcessor "org.androidannotations:androidannotations:$ANDROID_ANNOTATIONS_VERSION"
+    implementation "org.androidannotations:androidannotations-api:$ANDROID_ANNOTATIONS_VERSION"
+
+    annotationProcessor project(':intervalclick')
+    implementation project(':intervalclick-api')
+
+    implementation "com.android.support:appcompat-v7:$SUPPORT_VERSION"
+    implementation "com.android.support:design:$SUPPORT_VERSION"
 }

--- a/sample/src/main/java/moer/intervalclick/sample/MainActivity.java
+++ b/sample/src/main/java/moer/intervalclick/sample/MainActivity.java
@@ -1,6 +1,5 @@
 package moer.intervalclick.sample;
 
-import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -8,8 +7,9 @@ import android.view.View;
 import android.widget.Toast;
 
 import org.androidannotations.annotations.AfterViews;
+import org.androidannotations.annotations.Click;
 import org.androidannotations.annotations.EActivity;
-import org.androidannotations.annotations.ViewById;
+import org.androidannotations.annotations.InstanceState;
 
 import moer.intervalclick.R;
 import moer.intervalclick.api.IntervalClick;
@@ -17,26 +17,25 @@ import moer.intervalclick.api.IntervalClick;
 @EActivity(R.layout.activity_main)
 public class MainActivity extends AppCompatActivity {
 
-    @ViewById
-    FloatingActionButton fab;
-
     @AfterViews
     void afterViews() {
         Toolbar toolbar = (Toolbar) findViewById(moer.intervalclick.R.id.toolbar);
         setSupportActionBar(toolbar);
-
-        fab.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
-                        .setAction("Action", null).show();
-            }
-        });
     }
+
+    @Click(R.id.fab)
+    void snack(View view) {
+        Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
+                .setAction("Action", null).show();
+    }
+
+    @InstanceState
+    long mCounter;
 
     @IntervalClick
     void testButton() {
-        Toast.makeText(this, "Click!!", Toast.LENGTH_SHORT).show();
+
+        Toast.makeText(this, ++mCounter + " clicks!!", Toast.LENGTH_SHORT).show();
     }
 
 }


### PR DESCRIPTION
…sitive dependency (crash with JPrimitive)

+--- org.androidannotations:androidannotations:4.4.0
|    +--- org.androidannotations:androidannotations-api:4.4.0
|    \--- com.helger:jcodemodel:3.0.1
|         \--- com.google.code.findbugs:annotations:3.0.1u2
|              +--- net.jcip:jcip-annotations:1.0
|              \--- com.google.code.findbugs:jsr305:3.0.1
\--- com.github.m0er.androidannotations-interval-click-plugin:intervalclick:1.0.2
     +--- org.androidannotations:androidannotations:4.1.0 -> 4.4.0 (*)
     +--- com.github.m0er.androidannotations-interval-click-plugin:intervalclick-api:1.0.2
     |    \--- org.androidannotations:androidannotations-api:4.1.0 -> 4.4.0
     \--- com.helger:jcodemodel:2.8.4 -> 3.0.1 (*)